### PR TITLE
optimization

### DIFF
--- a/source/influxdb/api.d
+++ b/source/influxdb/api.d
@@ -222,6 +222,12 @@ struct Measurement {
             dg.formatValue(timestamp, fmt);
         }
     }
+
+    deprecated("Use std.conv.to!string instead.")
+    string toString()() {
+        import std.conv: to;
+        return this.to!string;
+    }
 }
 
 private void aaFormat(Dg, T : K[V], K, V)(scope Dg dg, scope T aa)
@@ -402,6 +408,12 @@ struct MeasurementSeries {
                     dg(value);
                 }
                 dg(")");
+            }
+
+            deprecated("Use std.conv.to!string instead.")
+            string toString()() {
+                import std.conv: to;
+                return this.to!string;
             }
         }
 

--- a/source/influxdb/api.d
+++ b/source/influxdb/api.d
@@ -248,7 +248,6 @@ private void aaFormat(Dg, T : K[V], K, V)(scope Dg dg, scope T aa)
 ///
 @("Measurement.to!string no timestamp")
 @safe unittest {
-    import std.stdio;
     import std.conv: to;
     {
         auto m = Measurement("cpu",

--- a/source/influxdb/api.d
+++ b/source/influxdb/api.d
@@ -58,10 +58,11 @@ struct DatabaseImpl(alias manageFunc, alias queryFunc, alias writeFunc) {
        Insert data into the DB.
      */
     void insert(in Measurement[] measurements) const {
-        import std.algorithm: map;
-        import std.array: array, join;
-        import std.conv: to;
-        writeFunc(url, db, measurements.map!(to!string).array.join("\n"));
+        import std.format: format;
+        static if (__VERSION__ >= 2074)
+            writeFunc(url, db, format!"%(%s\n%)"(measurements));
+        else
+            writeFunc(url, db, format("%(%s\n%)", measurements));
     }
 
     /**

--- a/source/influxdb/api.d
+++ b/source/influxdb/api.d
@@ -391,15 +391,16 @@ struct MeasurementSeries {
                 }
             }
 
-            string toString() @safe const pure nothrow {
-
-                import std.string: join;
-
-                string[] ret;
-                foreach(i, ref value; columnValues) {
-                    ret ~= columnNames[i] ~ ": " ~ value;
+            void toString(Dg)(scope Dg dg) const {
+                dg("Row(");
+                foreach(i, value; columnValues) {
+                    if (i)
+                        dg(", ");
+                    dg(columnNames[i]);
+                    dg(": ");
+                    dg(value);
                 }
-                return "Row(" ~ ret.join(", ") ~ ")";
+                dg(")");
             }
         }
 
@@ -480,6 +481,16 @@ struct MeasurementSeries {
                                     [["2015-06-11T20:46:02Z", "red", "blue"]]);
     series.rows[0].get("foo", "oops").shouldEqual("red");
     series.rows[0].get("quux", "oops").shouldEqual("oops");
+}
+
+///
+@("MeasurementSeries.Row.to!string")
+@safe pure unittest {
+    import std.conv: to;
+    auto series = MeasurementSeries("coolness",
+                                    ["time", "foo", "bar"],
+                                    [["2015-06-11T20:46:02Z", "red", "blue"]]);
+    series.rows[0].to!string.shouldEqual("Row(time: 2015-06-11T20:46:02Z, foo: red, bar: blue)");
 }
 
 ///


### PR DESCRIPTION
### Complexity

Lets R is number of rows and C is number of columns then
old deserialisation complexity is `O(R  * max(R * C))` (because `~=` usage in loop)
and new deserialisation complexity is `O(R * C)`.

### Memory allocations
 - Modern `toString` with delegates are used.
 - Predefined arrays length are used for deserialization
 - Reuses Asdf data for element values. This will reduce GC collection time because data allocated and scanned in single chunk. Plus deserialization of large data should be faster now.