### PR TITLE
mir integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ bin
 *.lib
 *.dll
 *.a
+mir-integration/mir-integration
+mir-integration/dub.selections.json
+*.sublime-project

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ sudo: true
 
 matrix:
   include:
-      {d: dmd , script: dub run --root mir-integration}
+      {d: dmd , script: dub run --root mir-integration && dub run --build=unittest -c integration-mir}
+      {d: ldc , script: dub run --root mir-integration && dub run --build=unittest -c integration-mir}
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: d
 dist: trusty
 sudo: true
 
+matrix:
+  include:
+      {d: dmd , script: dub run --root mir-integration}
+
+
 before_install:
   - curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
   - source /etc/lsb-release
@@ -17,7 +22,6 @@ before_script:
 script:
   - dub test
   - dub run --build=unittest -c integration
-  - dub run --root mir-integration
 
 matrix:
     include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_script:
 script:
   - dub test
   - dub run --build=unittest -c integration
+  - dub run --root mir-integration
 
 matrix:
     include:

--- a/dub.json
+++ b/dub.json
@@ -61,10 +61,22 @@
             "sourcePaths": ["source", "integration"],
             "dependencies": {
                 "unit-threaded": "~>0.7.0",
+            }
+
+        },
+
+        {
+            "name": "integration-mir",
+            "targetType": "executable",
+            "targetName": "bin/it",
+            "sourcePaths": ["source", "integration"],
+            "dependencies": {
+                "unit-threaded": "~>0.7.0",
                 "mir-algorithm": "~>0.6.0"
             }
 
         },
+
         {
             "name": "integration-ssl-1.1",
             "targetType": "executable",

--- a/dub.json
+++ b/dub.json
@@ -1,7 +1,8 @@
 {
     "name": "influx-d",
     "authors": [
-        "Atila Neves"
+        "Atila Neves",
+        "Ilya Yaroshenko"
     ],
     "dependencies": {
         "vibe-d": "~>0.8.0-beta.5",
@@ -59,7 +60,8 @@
             "targetName": "bin/it",
             "sourcePaths": ["source", "integration"],
             "dependencies": {
-                "unit-threaded": "~>0.7.0"
+                "unit-threaded": "~>0.7.0",
+                "mir-algorithm": "~>0.6.0"
             }
 
         },
@@ -69,7 +71,8 @@
             "targetName": "bin/it",
             "sourcePaths": ["source", "integration"],
             "dependencies": {
-                "unit-threaded": "~>0.7.0"
+                "unit-threaded": "~>0.7.0",
+                "mir-algorithm": "~>0.6.0"
             },
             "libs-posix": [
                 "ssl",

--- a/mir-integration/dub.json
+++ b/mir-integration/dub.json
@@ -1,0 +1,7 @@
+{
+	"name": "mir-integration",
+	"dependencies": {
+		"influx-d": {"path": "../"},
+		"mir-algorithm": "~>0.6.0"
+	}
+}

--- a/mir-integration/source/app.d
+++ b/mir-integration/source/app.d
@@ -1,0 +1,43 @@
+/++
+Include mir-algorithm into your project.
+
+See_also:
+	$(LINK2 http://docs.algorithm.dlang.io/latest/mir_timeseries.html, mir.timeseries).
++/
+import influxdb;
+import mir.timeseries;
+import std.datetime: DateTime;
+
+void main()
+{
+	auto influxSeries = MeasurementSeries("coolness",
+        ["time", "foo", "bar"],
+        [
+            ["2015-06-11T20:46:02Z", "1.0", "2.0"],
+            ["2013-02-09T12:34:56Z", "3.0", "4.0"],
+        ]);
+
+    auto series = influxSeries.rows.toMirSeries;
+
+    // sort data if required
+    {
+        import mir.ndslice.algorithm: all;
+        import mir.ndslice.allocation: uninitSlice;
+        import mir.ndslice.topology: pairwise;
+
+        if (!series.time.pairwise!"a <= b".all)
+        {
+            series.sort(
+                uninitSlice!size_t(series.length), // index buffer
+                uninitSlice!double(series.length)); // data buffer
+        }
+    }
+
+    assert(series.time == [
+        DateTime(2013,  2,  9, 12, 34, 56),
+        DateTime(2015,  6, 11, 20, 46,  2)]);
+
+    assert(series.data == [
+        [3.0, 4.0],
+        [1.0, 2.0]]);
+}

--- a/source/influxdb/mir.d
+++ b/source/influxdb/mir.d
@@ -14,6 +14,13 @@ module influxdb.mir;
 
 version(Have_mir_algorithm):
 
+static if (__VERSION__ >= 2073)
+    version = Have_influxdb_mir;
+else
+    pragma(msg, "Warning: influxdb.mir requires DMD Front End >= 2073");
+
+version(Have_influxdb_mir):
+
 import mir.timeseries;
 import influxdb.api;
 import std.datetime: DateTime;

--- a/source/influxdb/mir.d
+++ b/source/influxdb/mir.d
@@ -15,12 +15,8 @@ module influxdb.mir;
 version(Have_mir_algorithm):
 
 static if (__VERSION__ >= 2073)
-    version = Have_influxdb_mir;
-else
-    pragma(msg, "Warning: influxdb.mir requires DMD Front End >= 2073");
-
-version(Have_influxdb_mir):
-
+{
+////////////////////////////////////
 import mir.timeseries;
 import influxdb.api;
 import std.datetime: DateTime;
@@ -111,3 +107,7 @@ unittest
         [3.0, 4.0],
         [1.0, 2.0]]);
 }
+////////////////////////////////////
+}
+else
+    pragma(msg, "Warning: influxdb.mir requires DMD Front End >= 2073");

--- a/source/influxdb/mir.d
+++ b/source/influxdb/mir.d
@@ -1,0 +1,106 @@
+/++
+Conversion utilities that help to work with Mir Series and ndslice.
+
+To use this module `mir-algorithm` package should be included into users `dub.json` file.
+
+Public_imports:
+    mir.timeserires
+
+Authors: Ilya Yaroshenko
+Copyright: Kaleidic Associates Advisory Limited
+License: BSD 3-clause
++/
+module influxdb.mir;
+
+version(Have_mir_algorithm):
+
+import mir.timeseries;
+import influxdb.api;
+import std.datetime: DateTime;
+
+/++
+Converts MeasurementSeries.Rows to Mir Series.
+
+Params:
+    T = Time type. Default time type is DateTime. Supported types are SysTime, DateTime, and Date.
+    D = Data type. Default data type is double.
+    rows = MeasurementSeries rows
+    columns = List of columns (optional). The "time" colummn is ignored.
+Returns:
+    2D Mir $(LINK2 https://docs.algorithm.dlang.io/latest/mir_timeseries.html, Series).
++/
+Series!(T*, Contiguous, [2], D*)
+    toMirSeries(T = DateTime, D = double)(
+        MeasurementSeries.Rows rows,
+        const(string)[] columns = null)
+{
+    // if columns are not set use all columns
+    if (columns is null)
+    {
+        columns = rows.columns;
+    }
+    // always exclude "time" column
+    foreach (i, column; columns)
+    {
+        if (column == "time")
+        {
+            columns = columns[0 .. i] ~ columns[i + 1 .. $];
+            break;
+        }
+    }
+    import mir.ndslice.allocation: slice, uninitSlice;
+    import mir.ndslice.topology: map, as;
+    import std.conv: to;
+    auto time = rows["time"].slicedField.map!influxSysTime.as!T.slice;
+    auto data = uninitSlice!D(time.length, columns.length);
+    foreach (i, column; columns)
+    {
+        auto from = rows[column];
+        foreach (ref elem; data[0 .. $, i])
+        {
+            elem = from.front.to!D;
+            from.popFront;
+        }
+        assert(from.empty);
+    }
+    return time.series(data);
+}
+
+///
+@("toMirSeries")
+unittest
+{
+    import mir.timeseries;
+    import std.datetime: DateTime;
+
+    auto influxSeries = MeasurementSeries("coolness",
+        ["time", "foo", "bar"],
+        [
+            ["2015-06-11T20:46:02Z", "1.0", "2.0"],
+            ["2013-02-09T12:34:56Z", "3.0", "4.0"],
+        ]);
+
+    auto series = influxSeries.rows.toMirSeries;
+
+    // sort data if required
+    {
+        import mir.ndslice.algorithm: all;
+        import mir.ndslice.allocation: uninitSlice;
+        import mir.ndslice.topology: pairwise;
+
+        if (!series.time.pairwise!"a <= b".all)
+        {
+            series.sort(
+                uninitSlice!size_t(series.length), // index buffer
+                uninitSlice!double(series.length)); // data buffer
+        }
+    }
+
+    assert(series.time == [
+        DateTime(2013,  2,  9, 12, 34, 56),
+        DateTime(2015,  6, 11, 20, 46,  2)]);
+
+    assert(series.data == [
+        [3.0, 4.0],
+        [1.0, 2.0]]);
+}

--- a/source/influxdb/package.d
+++ b/source/influxdb/package.d
@@ -14,3 +14,6 @@
 module influxdb;
 
 public import influxdb.api;
+
+version(Have_mir_algorithm)
+	public import influxdb.mir;


### PR DESCRIPTION
Project does not include mir-algorithm as dependency. User should
include mir-algorithm if he want to use influxdb.mir functionality.

mir-algorithm is sourceLibrary and we can do such tricks to avoid
dependency version races.

mir-integration project was added to prove the idea.