### PR TITLE
trusted stderr

### DIFF
--- a/source/influxdb/api.d
+++ b/source/influxdb/api.d
@@ -36,7 +36,10 @@ SysTime influxSysTime(string time) @safe
         import std.stdio: stderr;
         import std.algorithm: countUntil;
 
-        debug stderr.writeln("Could not convert ", time, " due to a Phobos bug, reducing precision");
+        debug {
+            (() @trusted => stderr)()
+                .writeln("Could not convert ", time, " due to a Phobos bug, reducing precision");
+        }
 
         // find where the fractional part starts
         auto dotIndex = time.countUntil(".");


### PR DESCRIPTION
it would be great if the `std{in,out,err}` properties were `@trusted`, but they aren't.