### PR TITLE
Change field values to work with value types instead of string

### DIFF
--- a/source/influxdb/api.d
+++ b/source/influxdb/api.d
@@ -853,10 +853,10 @@ struct InfluxValue {
 @safe unittest {
     import std.conv: to;
     import std.datetime: SysTime;
-    import std.typecons : nullable;
+    import std.typecons : Nullable;
 
     Measurement("cpu",
-                ["foo": InfluxValue("true", InfluxValue.Type.bool_.nullable)],
+                ["foo": InfluxValue("true", Nullable!(InfluxValue.Type)(InfluxValue.Type.bool_))],
                 SysTime.fromUnixTime(7))
         .to!string.shouldEqualLine(`cpu foo=true 7000000000`);
 }
@@ -865,10 +865,10 @@ struct InfluxValue {
 @safe unittest {
     import std.conv: to;
     import std.datetime: SysTime;
-    import std.typecons : nullable;
+    import std.typecons : Nullable;
 
     Measurement("cpu",
-                ["foo": InfluxValue("42", InfluxValue.Type.int_.nullable)],
+                ["foo": InfluxValue("42", Nullable!(InfluxValue.Type)(InfluxValue.Type.int_))],
                 SysTime.fromUnixTime(7))
         .to!string.shouldEqualLine(`cpu foo=42i 7000000000`);
 }
@@ -877,10 +877,10 @@ struct InfluxValue {
 @safe unittest {
     import std.conv: to;
     import std.datetime: SysTime;
-    import std.typecons : nullable;
+    import std.typecons : Nullable;
 
     Measurement("cpu",
-                ["foo": InfluxValue("42i", InfluxValue.Type.int_.nullable)],
+                ["foo": InfluxValue("42i", Nullable!(InfluxValue.Type)(InfluxValue.Type.int_))],
                 SysTime.fromUnixTime(7))
         .to!string.shouldEqualLine(`cpu foo=42i 7000000000`);
 }
@@ -889,10 +889,10 @@ struct InfluxValue {
 @safe unittest {
     import std.conv: to;
     import std.datetime: SysTime;
-    import std.typecons : nullable;
+    import std.typecons : Nullable;
 
     Measurement("cpu",
-                ["foo": InfluxValue("1.2", InfluxValue.Type.float_.nullable)],
+                ["foo": InfluxValue("1.2", Nullable!(InfluxValue.Type)(InfluxValue.Type.float_))],
                 SysTime.fromUnixTime(7))
         .to!string.shouldEqualLine(`cpu foo=1.2 7000000000`);
 }


### PR DESCRIPTION
* this way lot of GC allocations is avoided when values are used directly as they aren't converted to the intermediate string, but formatted to the output based on their type
* when direct value is used it isn't needed to guess the value type (string is handled as a string right away)
* change shouldn't break the current users code as string[string] field values are still type guessed as before
* added the unittest  which leads me to this change as I wanted to insert string value which accindentally looks to be a valid float number but isn't and with type guess from string values it wasn't possible to force the known type