### PR TITLE
Fix empty strings in InfluxValue

### DIFF
--- a/source/influxdb/api.d
+++ b/source/influxdb/api.d
@@ -533,7 +533,7 @@ private auto escape(Dg)(scope Dg dg, in char[] chars...) {
 
 private auto valueIsString(T)(in T value) {
     static if (is(T == string)) return true;
-    else static if (is(T == InfluxValue)) return value.type == InfluxValue.Type.string;
+    else static if (is(T == InfluxValue)) return value.type == InfluxValue.Type.string_;
     else static assert(0, format!"Unexpected value type %s"(typeid(T)));
 }
 
@@ -557,7 +557,7 @@ private auto guessValueType(string value) @safe pure nothrow @nogc {
     // test for float values
     if (valueIsFloat(value)) return InfluxValue.Type.float_;
 
-    return InfluxValue.Type.string;
+    return InfluxValue.Type.string_;
 }
 
 private bool valueIsFloat(in string value) @safe pure nothrow @nogc {
@@ -728,7 +728,7 @@ struct InfluxValue {
 
     import std.typecons : Nullable;
 
-    enum Type { bool_, int_, float_, string }
+    enum Type { bool_, int_, float_, string_ }
 
     union Payload {
         bool b;
@@ -759,7 +759,7 @@ struct InfluxValue {
         _type = InfluxValue.Type.float_;
     }
 
-    this(string v, Nullable!Type type = Nullable!Type(Type.string)) @safe pure nothrow {
+    this(string v, Nullable!Type type = Nullable!Type(Type.string_)) @safe pure nothrow {
         _rawString = v;
         if (type.isNull) _type = guessValueType(v);
         else _type = type;
@@ -783,7 +783,7 @@ struct InfluxValue {
                 case bool_: dg.formatValue(_value.b, fmt); break;
                 case int_: dg.formattedWrite("%si", _value.i, fmt); break;
                 case float_: dg.formatValue(_value.f, fmt); break;
-                case string: assert(0);
+                case string_: assert(0);
             }
         }
     }

--- a/source/influxdb/api.d
+++ b/source/influxdb/api.d
@@ -738,7 +738,7 @@ struct InfluxValue {
 
     private {
         Payload _value;
-        string _rawString;
+        string _rawString = null;
         Type _type;
     }
 
@@ -759,7 +759,10 @@ struct InfluxValue {
         _type = InfluxValue.Type.float_;
     }
 
-    this(string v, Nullable!Type type = Nullable!Type(Type.string_)) @safe pure nothrow {
+    this(string v, Nullable!Type type = Nullable!Type(Type.string_)) @safe pure nothrow
+    in {
+        assert(v !is null);
+    } body {
         _rawString = v;
         if (type.isNull) _type = guessValueType(v);
         else _type = type;
@@ -774,7 +777,7 @@ struct InfluxValue {
         import std.format: FormatSpec, formattedWrite, formatValue;
 
         FormatSpec!char fmt;
-        if (_rawString.length) {
+        if (_rawString !is null) {
             if (_type == Type.int_ && _rawString[$-1] != 'i') dg.formattedWrite("%si", _rawString, fmt);
             else dg.formatValue(_rawString, fmt);
         }
@@ -847,6 +850,17 @@ struct InfluxValue {
                 ["foo": InfluxValue("bar")],
                 SysTime.fromUnixTime(7))
         .to!string.shouldEqualLine(`cpu foo="bar" 7000000000`);
+}
+
+@("Measurement.to!string InfluxValue empty string")
+@safe unittest {
+    import std.conv: to;
+    import std.datetime: SysTime;
+
+    Measurement("cpu",
+                ["foo": InfluxValue("")],
+                SysTime.fromUnixTime(7))
+        .to!string.shouldEqualLine(`cpu foo="" 7000000000`);
 }
 
 @("Measurement.to!string InfluxValue string escaping")


### PR DESCRIPTION
using `string` as an enum member may work, but it's just needlessly confusing.

`null` is a better special value to signify "unused" than emptiness