### PR TITLE
fix empty strings in InfluxValue: take 2

### DIFF
--- a/source/influxdb/api.d
+++ b/source/influxdb/api.d
@@ -738,7 +738,7 @@ struct InfluxValue {
 
     private {
         Payload _value;
-        string _rawString;
+        string _rawString = null;
         Type _type;
     }
 
@@ -759,7 +759,10 @@ struct InfluxValue {
         _type = InfluxValue.Type.float_;
     }
 
-    this(string v, Nullable!Type type = Nullable!Type(Type.string_)) @safe pure nothrow {
+    this(string v, Nullable!Type type = Nullable!Type(Type.string_)) @safe pure nothrow
+    in {
+        assert(v !is null);
+    } body {
         _rawString = v;
         if (type.isNull) _type = guessValueType(v);
         else _type = type;
@@ -774,7 +777,7 @@ struct InfluxValue {
         import std.format: FormatSpec, formattedWrite, formatValue;
 
         FormatSpec!char fmt;
-        if (_rawString.length) {
+        if (_rawString !is null) {
             if (_type == Type.int_ && _rawString[$-1] != 'i') dg.formattedWrite("%si", _rawString, fmt);
             else dg.formatValue(_rawString, fmt);
         }
@@ -847,6 +850,17 @@ struct InfluxValue {
                 ["foo": InfluxValue("bar")],
                 SysTime.fromUnixTime(7))
         .to!string.shouldEqualLine(`cpu foo="bar" 7000000000`);
+}
+
+@("Measurement.to!string InfluxValue empty string")
+@safe unittest {
+    import std.conv: to;
+    import std.datetime: SysTime;
+
+    Measurement("cpu",
+                ["foo": InfluxValue("")],
+                SysTime.fromUnixTime(7))
+        .to!string.shouldEqualLine(`cpu foo="" 7000000000`);
 }
 
 @("Measurement.to!string InfluxValue string escaping")


### PR DESCRIPTION
I really don't see why when influxdb supports empty strings, influx-d does not.