### PR TITLE
Upgraded project. Reason: requests to 2.0.9 doesn't work with openssl >=3.0

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -5,7 +5,7 @@
         "Ilya Yaroshenko"
     ],
     "dependencies": {
-        "requests": "~>2.0.9",
+        "requests": "~>2.2",
         "asdf": ">=0.1.1 <0.8.0"
     },
     "description": "InfluxDB wrapper",

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,13 +1,14 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"asdf": "0.7.2",
-		"automem": "0.6.9",
-		"cachetools": "0.4.1",
-		"mir-algorithm": "3.10.12",
-		"mir-core": "1.1.40",
-		"requests": "2.0.9",
+		"asdf": "0.7.17",
+		"automem": "0.6.11",
+		"cachetools": "0.4.2",
+		"mir-algorithm": "3.22.4",
+		"mir-core": "1.7.3",
+		"requests": "2.2.0",
+		"silly": "1.1.1",
 		"test_allocator": "0.3.4",
-		"unit-threaded": "1.0.11"
+		"unit-threaded": "2.2.3"
 	}
 }


### PR DESCRIPTION
Influx-d was using requests 2.0.9 which in turn didn't work with newer versions of openssl. Project is upgraded to use the latest versions the dependencies 